### PR TITLE
Fix: set locale

### DIFF
--- a/_assets/js/app.js
+++ b/_assets/js/app.js
@@ -98,10 +98,8 @@
 
         var mmt = moment ();
 
-        if (local.properties.language) {
-            if (local.properties.language.length > 0){
-                mmt.locale(local.properties.language[0].iso639_1);
-            }
+        if (local.properties.lang) {
+            mmt.locale(local.properties.lang);
         }
 
         if (local.properties.timezone) {


### PR DESCRIPTION
Edits:
- /v1/location returns `{'lang': 'en'}` not `language`