### PR TITLE
Guard GA + Sentry tags against unset ENV

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -22,19 +22,23 @@ const Layout = (props) => html`<!DOCTYPE html>
         crossorigin
       />
       <link rel="stylesheet" href="/static/styles/main.css?v=${props.v}" />
-      <script
-        src="https://js.sentry-cdn.com/${props.sentryId}.min.js"
-        crossorigin="anonymous"
-      ></script>
-      <!-- Google tag (gtag.js) -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id=${props.gaId}"></script>
-      <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
+      ${props.sentryId
+        ? html`<script
+            src="https://js.sentry-cdn.com/${props.sentryId}.min.js"
+            crossorigin="anonymous"
+          ></script>`
+        : ''}
+      ${props.gaId
+        ? html`<!-- Google tag (gtag.js) -->
+          <script async src="https://www.googletagmanager.com/gtag/js?id=${props.gaId}"></script>
+          <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
 
-        gtag('config', '${props.gaId}');
-      </script>
+            gtag('config', '${props.gaId}');
+          </script>`
+        : ''}
       <script src="/static/js/main.js?v=${props.v}" async defer></script>
     </head>
     <body>

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { jsx } from 'hono/jsx'
 import App from './components/App'
+import { gaIds, sentryIds } from './constants'
 
 // The Cloudflare static-assets middleware and its build-time manifest only
 // exist in the Workers runtime; stub both before importing the app.
@@ -103,6 +104,37 @@ describe('Page render (/ route)', () => {
 
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('CACHED PAGE')
+  })
+})
+
+describe('Analytics integration (gtag.js / Sentry)', () => {
+  const render = (env) =>
+    jsx(App, { env, country: 'US', timezone: 'America/New_York', v: 'x' }).toString()
+
+  it('injects the environment-specific GA measurement ID and Sentry DSN', () => {
+    const body = render('production')
+    expect(body).toContain(`gtag/js?id=${gaIds.production}`)
+    expect(body).toContain(`gtag('config', '${gaIds.production}')`)
+    expect(body).toContain(`https://js.sentry-cdn.com/${sentryIds.production}.min.js`)
+  })
+
+  it('uses the stage IDs under the stage environment', () => {
+    const body = render('stage')
+    expect(body).toContain(`gtag/js?id=${gaIds.stage}`)
+    expect(body).toContain(`gtag('config', '${gaIds.stage}')`)
+    expect(body).toContain(`https://js.sentry-cdn.com/${sentryIds.stage}.min.js`)
+  })
+
+  it('omits the GA and Sentry tags entirely when ENV is unset', () => {
+    // Local dev, `wrangler dev`, and the default *.workers.dev deploy have no
+    // ENV var, so gaIds[env]/sentryIds[env] are undefined. The snippet must be
+    // skipped rather than rendered with an empty id (which would load gtag.js
+    // with no measurement ID and ping GA / Sentry with junk requests).
+    const body = render(undefined)
+    expect(body).not.toContain('googletagmanager.com/gtag/js')
+    expect(body).not.toContain('gtag(')
+    expect(body).not.toContain('sentry-cdn.com')
+    expect(body).not.toContain('id=""')
   })
 })
 


### PR DESCRIPTION
## Summary

Reviewed the Google Analytics integration. The wiring is correct for `stage` and `production` (measurement IDs flow `constants.js → App.jsx → Layout.jsx`, the GA4 snippet is standard, and the client-side `device` event is safely guarded). The one defect was at the unconfigured edges.

When `ENV` is unset — the case for the default `*.workers.dev` deploy, `[env.dev]`, and `wrangler dev` (only `[env.stage]`/`[env.production]` set `ENV` in `wrangler.toml`) — `gaIds[env]`/`sentryIds[env]` are `undefined`, which `hono/html` renders as an empty string. The page then emitted:

- `https://www.googletagmanager.com/gtag/js?id=` — gtag.js loaded with no measurement ID
- `gtag('config', '')` — configures an empty property
- `https://js.sentry-cdn.com/.min.js` — same problem for Sentry

i.e. broken analytics requests, console errors, and junk hits on every non-prod/stage surface.

## Fix

Only inject the GA and Sentry snippets when an id is present (`Layout.jsx`). The client side needs no change — `main.js` already gates events on `typeof gtag !== 'undefined'`, so the `device` event is cleanly skipped when the snippet is omitted.

## Tests

Added regression tests in `src/index.test.js`:
- `production` / `stage` render the correct environment-specific GA measurement ID and Sentry DSN
- an unset `ENV` renders **no** gtag/Sentry tags (rather than empty-id tags)

`bun test` → 23 pass / 0 fail. `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)