### PR TITLE
Remove abandoned-project warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A full-screen localized clock for digital signage, deployed as a Cloudflare Worker. The page is server-rendered by [Hono](https://hono.dev/) JSX at the edge; the worker reads the viewer's location from Cloudflare's `cf` object (country + IANA timezone) and injects it into the HTML, then client-side JS uses `Intl` to render the local wall-clock time, date, and 12/24h format in the location's language.
 
-Note: the README marks this project as **abandoned** in favor of the Clock Edge App, but the codebase is current and tested.
+Note: active development has moved to the Clock Edge App, but this codebase is current and tested.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Screenly Clock App
 
-**Warning:** This project has been abandoned in favor of the [Clock Edge App](https://github.com/Screenly/Playground/tree/master/edge-apps/clock).
-
 ![Clock App Screenshot](assets/screenshot.jpg)
 
 This is an example asset for Screenly as part of the [Screenly Playground](https://github.com/Screenly/playground).


### PR DESCRIPTION
Removes the "This project has been abandoned" warning from the README, and updates the corresponding note in `CLAUDE.md` to reflect that this codebase is current and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)