### PR TITLE
Add signage-app manifest and honor its 24h clock-format setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Lint (Biome)
         run: bun run lint
+      - name: Validate signage-app manifest is valid JSON
+        run: jq empty signage-app.json
       - name: Test
         run: bun test

--- a/assets/static/js/locale.js
+++ b/assets/static/js/locale.js
@@ -33,6 +33,12 @@ let dateFormatterLong
 let dateFormatterShort
 let hourFormatter
 
+// Optional 12/24h override from the ?24h launch setting (see the signage-app
+// manifest's `24h` enum): undefined = follow the locale's own default, true =
+// force 12-hour, false = force 24-hour. Kept separate from `locale` so the
+// setting overrides only the clock face, not the language of names/date.
+let hour12Override
+
 // Only pass timeZone to Intl when it is a non-empty, valid IANA name; an
 // invalid zone makes the DateTimeFormat constructor throw.
 const zoneOpt = () => (timeZone ? { timeZone } : {})
@@ -44,7 +50,10 @@ const buildFormatters = () => {
   // makes every formatter render the location's wall clock from an absolute
   // instant, independent of the device's own timezone.
   const z = zoneOpt()
-  const timeOpts = { hour: 'numeric', minute: '2-digit', ...z }
+  // hour12 is only set when the ?24h setting forces it; otherwise it is omitted
+  // so Intl keeps the locale's native 12/24h convention (and its AM/PM part).
+  const h12 = hour12Override !== undefined ? { hour12: hour12Override } : {}
+  const timeOpts = { hour: 'numeric', minute: '2-digit', ...h12, ...z }
   const dateLongOpts = { weekday: 'long', month: 'long', day: 'numeric', calendar: 'gregory', ...z }
   const dateShortOpts = {
     weekday: 'short',
@@ -66,7 +75,7 @@ const buildFormatters = () => {
     // safe locale rather than break the clock.
     locale = FALLBACK_LOCALE
     timeZone = undefined
-    timeFormatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' })
+    timeFormatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit', ...h12 })
     dateFormatterLong = new Intl.DateTimeFormat(locale, {
       weekday: 'long',
       month: 'long',
@@ -95,6 +104,14 @@ export const resolveLocale = (code) => locales[code] || FALLBACK_LOCALE
 // a falsy value clears it, so the clock uses the device's own zone.
 export const setTimeZone = (tz) => {
   timeZone = tz || undefined
+  buildFormatters()
+}
+
+// Apply the ?24h launch setting: '0' => 12-hour, '1' => 24-hour; any other
+// value (including '' or null, the manifest's "Default") clears the override so
+// the locale's own convention decides. Values mirror the manifest's `24h` enum.
+export const setHourFormat = (value) => {
+  hour12Override = value === '0' ? true : value === '1' ? false : undefined
   buildFormatters()
 }
 

--- a/assets/static/js/main.js
+++ b/assets/static/js/main.js
@@ -1,6 +1,7 @@
 import {
   setLocale,
   setTimeZone,
+  setHourFormat,
   formatTimeParts,
   formatDate,
   getZonedHour,
@@ -112,6 +113,9 @@ import {
     // sign shows the local wall clock even if the device's own clock is wrong.
     setLocale(getCountry())
     setTimeZone(getTimeZone())
+    // Optional ?24h launch setting (from the signage-app manifest) overrides the
+    // locale's default 12/24h clock face; absent => locale decides.
+    setHourFormat(new URLSearchParams(window.location.search).get('24h'))
     syncMinuteFill()
     renderClock()
     setBanner()

--- a/signage-app.json
+++ b/signage-app.json
@@ -8,7 +8,7 @@
   "tags": ["Clock"],
   "source": "https://github.com/Screenly-Labs/clock-app",
   "support": "https://github.com/Screenly-Labs/clock-app/issues",
-  "playback": { "duration": 30, "refreshIntervalS": 3600 },
+  "playback": { "pacing": "fixed", "refreshIntervalS": 3600 },
   "settings": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",

--- a/signage-app.json
+++ b/signage-app.json
@@ -1,0 +1,29 @@
+{
+  "manifestVersion": "1",
+  "id": "clock",
+  "name": "Digital Clock",
+  "description": "A clean digital clock that shows the local time on any screen.",
+  "summary": "Always-on local time for any display.",
+  "vendor": "Screenly",
+  "tags": ["Clock"],
+  "source": "https://github.com/Screenly-Labs/clock-app",
+  "support": "https://github.com/Screenly-Labs/clock-app/issues",
+  "playback": { "duration": 30, "refreshIntervalS": 3600 },
+  "settings": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "24h": {
+        "type": "string",
+        "title": "Clock format",
+        "default": "",
+        "enum": ["", "0", "1"],
+        "x-enumLabels": ["Default", "12-hour", "24-hour"]
+      }
+    }
+  },
+  "launch": {
+    "baseUrl": "https://clock.srly.io/",
+    "template": "{?24h}"
+  }
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,6 +3,7 @@ import { logger } from 'hono/logger'
 import { serveStatic } from 'hono/cloudflare-workers'
 import manifest from '__STATIC_CONTENT_MANIFEST'
 import App from './components/App'
+import signageManifest from '../signage-app.json'
 
 const app = new Hono()
 
@@ -37,6 +38,17 @@ app.use('/static/*', async (c, next) => {
   )
 })
 app.use('/static/*', serveStatic({ root: './', manifest }))
+
+// Signage-app manifest: the app-store index and signage players fetch this
+// cross-origin to render the settings form and build the launch URL, so it must
+// be anonymous, JSON, and CORS-open. Served from the worker (not /static) so the
+// dotfile `.well-known/` path and headers are guaranteed regardless of host.
+app.get('/.well-known/signage-app.json', (c) => {
+  c.header('Content-Type', 'application/json')
+  c.header('Access-Control-Allow-Origin', '*')
+  c.header('Cache-Control', 'public, max-age=3600')
+  return c.body(JSON.stringify(signageManifest))
+})
 
 app.get('/', async (c) => {
   const env = c.env.ENV

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -138,6 +138,26 @@ describe('Analytics integration (gtag.js / Sentry)', () => {
   })
 })
 
+describe('Signage-app manifest (/.well-known/signage-app.json)', () => {
+  it('serves the manifest as JSON with open CORS for the store and players', async () => {
+    const res = await app.request('http://localhost/.well-known/signage-app.json')
+
+    expect(res.status).toBe(200)
+    // Cross-origin consumers (store index + players) require open CORS and JSON.
+    expect(res.headers.get('Content-Type')).toContain('application/json')
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+
+    const body = await res.json()
+    expect(body.manifestVersion).toBe('1')
+    expect(body.id).toBe('clock')
+    // The setting name + enum values must match the query param the app accepts.
+    expect(body.settings.properties['24h'].enum).toEqual(['', '0', '1'])
+    // baseUrl must be https with a trailing slash; template drops empty 24h.
+    expect(body.launch.baseUrl).toBe('https://clock.srly.io/')
+    expect(body.launch.template).toBe('{?24h}')
+  })
+})
+
 describe('Static asset caching (/static/*)', () => {
   it('caches versioned assets immutably and unversioned ones briefly', async () => {
     // Versioned URL (?v=...) is content-addressed via the query, so it is safe

--- a/test/locale.test.js
+++ b/test/locale.test.js
@@ -8,6 +8,7 @@ import {
   resolveLocale,
   setLocale,
   setTimeZone,
+  setHourFormat,
   formatTime,
   formatTimeParts,
   formatDate,
@@ -91,6 +92,44 @@ describe('time formatting (12h / 24h, localized, zoned)', () => {
     setTimeZone('')
     // No throw, and a well-formed 24h string for en-GB.
     expect(formatTime(INSTANT)).toMatch(/^\d{1,2}:\d{2}$/)
+  })
+})
+
+describe('setHourFormat (?24h launch setting override)', () => {
+  // Force a locale whose native convention is the opposite of each override, so a
+  // passing assertion proves the override — not the locale default — is in effect.
+  it("forces 24-hour with '1' even for a 12h locale (en-US)", () => {
+    setLocale('US')
+    setTimeZone('America/New_York')
+    setHourFormat('1')
+    const { time, period } = formatTimeParts(INSTANT)
+    // 13:30 UTC -> 09:30 New York (EDT), shown 24-hour with no AM/PM part.
+    expect(time).toBe('09:30')
+    expect(period).toBe('')
+    setHourFormat('')
+  })
+
+  it("forces 12-hour with '0' even for a 24h locale (en-GB)", () => {
+    setLocale('GB')
+    setTimeZone('Europe/London')
+    setHourFormat('0')
+    const { time, period } = formatTimeParts(INSTANT)
+    expect(time).toBe('2:30')
+    expect(period).toMatch(/PM/i)
+    setHourFormat('')
+  })
+
+  it("follows the locale default for '' / null / unknown values", () => {
+    setLocale('US')
+    setTimeZone('America/New_York')
+    setHourFormat('1')
+    // Clearing the override restores en-US's native 12-hour clock.
+    setHourFormat('')
+    expect(formatTimeParts(INSTANT).period).toMatch(/AM/i)
+    setHourFormat(null)
+    expect(formatTimeParts(INSTANT).period).toMatch(/AM/i)
+    setHourFormat('bogus')
+    expect(formatTimeParts(INSTANT).period).toMatch(/AM/i)
   })
 })
 


### PR DESCRIPTION
## What

Publishes the signage-app manifest at `/.well-known/signage-app.json` so the app store and signage players can render the settings form and build the launch URL, and makes the app actually honor the setting the manifest advertises.

## Changes

- **`signage-app.json`** — the manifest (identity, `playback`, one `24h` "Clock format" setting, `launch` template). Validated against the store schema (`app-store` repo, draft 2020-12) and served with `pacing: "fixed"` per the current spec.
- **`src/index.jsx`** — a worker route serving it with `Content-Type: application/json`, `Access-Control-Allow-Origin: *`, and an anonymous, dotfile-safe path (served from the worker, not `/static`).
- **`assets/static/js/locale.js` + `main.js`** — the manifest advertises a `24h` setting mapped to `?24h`, but the app previously derived 12/24h from locale only and ignored the param, making the setting a no-op. Wired it up: a `hour12` override (`setHourFormat`) kept separate from locale so only the clock face changes. `'0'` → 12h, `'1'` → 24h, empty → locale default — matching the manifest enum.
- **`.github/workflows/ci.yml`** — a `jq empty` step that fails CI if `signage-app.json` is ever malformed JSON.

## Verification

- Manifest validates against the store schema (`uri` format-checked).
- Launch URLs match the spec's table: `""` → `https://clock.srly.io/`, `"0"` → `?24h=0`, `"1"` → `?24h=1`.
- Unit tests (27 pass): route returns correct JSON + CORS headers; `setHourFormat` forces 12/24h against locales whose defaults are the opposite.
- End-to-end in a real browser (Playwright): default en-US shows `AM/PM`; `?24h=1` drops it and shows 24h; `?24h=0` keeps 12h.
- Client bundle still builds and stays export-free (the load-bearing build constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)