### PR TITLE
Raise CSS floor to Chrome 87 / Safari 14.1 (logical properties)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   },
   "license": "AGPL-3.0-only",
   "browserslist": [
-    "chrome >= 79",
-    "firefox >= 75",
-    "safari >= 11.1",
-    "edge >= 79"
+    "chrome >= 87",
+    "firefox >= 78",
+    "safari >= 14.1",
+    "edge >= 87"
   ],
   "dependencies": {
     "@fontsource-variable/fraunces": "^5.2.9",


### PR DESCRIPTION
Follow-up to the degraded-mode work. **Bug:** on browsers below Chrome 87 / Safari 14.1, CSS logical properties (`inset-inline-end`, `margin-inline-end`, …) were dropped — Lightning CSS lowered them to `:not(:-webkit-any(:lang(…)))`-guarded physical rules that those browsers reject as invalid. Most visible symptom: the rss-reader QR fell to the left, overlapping text.

**Fix:** raise the `browserslist` floor to `chrome >= 87`, `safari >= 14.1`, `firefox >= 78`, `edge >= 87` — where these logical properties are native, so Lightning CSS keeps them as-is. All other down-leveling (clamp→max(min), @layer flatten, svh/cqw fallbacks, color-mix) remains in effect.

Build-time only (browserslist is read at build); verified: 0 fragile `:lang()` selectors in output, logical props native, typecheck/lint/tests/es-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)