### PR TITLE
Run CI on release PRs into production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,12 @@
 name: CI
 
 on:
+  # `production` is here because a release PR (master -> production) is the last
+  # gate before a deploy that users see, and without it that PR runs no checks at
+  # all — the only status it shows is the stage deploy from the master merge,
+  # which is easy to misread as CI having passed.
   pull_request:
-    branches: [master, main]
+    branches: [master, main, production]
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
A release PR (`master` → `production`) is the last gate before a deploy users see, and it was the one PR that ran no checks — CI triggered only on `pull_request` into `master`/`main`.

The failure mode is worse than a missing signal. GitHub still shows a green **Deploy** status on such a PR (the stage deploy from the earlier master merge, attached to the same head commit), which reads as CI having passed when lint and tests never ran. That is exactly how #30 looked when it was merged to production.

For the record, #30 *was* covered — its tree hashed identical (`17d5cc47…`) to the tree CI passed on in #29, so nothing shipped untested. But establishing that took a manual `git rev-parse ^{tree}` comparison, which is not a check.

## Change

```diff
 on:
   pull_request:
-    branches: [master, main]
+    branches: [master, main, production]
```

## Verification

This PR targets `master`, so it cannot exercise the new trigger on itself — the `production` entry only takes effect once merged, on the next release PR. What it does prove is that the workflow still parses and the existing trigger is intact:

- `yaml.safe_load` → `branches: ['master', 'main', 'production']`, job `lint-and-test` intact.
- The **Lint and Test** check on this PR confirms the `master` trigger still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)