### PR TITLE
Report the detected player to GA4

### DIFF
--- a/assets/static/js/analytics.js
+++ b/assets/static/js/analytics.js
@@ -1,0 +1,67 @@
+// GA4 player telemetry: reports which player is showing the clock, from the
+// profile signage-kit already builds for the stale-player notice. Extracted from
+// main.js so the param mapping can be unit-tested with a real ES module import —
+// main.js bundles this in and must stay export-free (see the build note there).
+//
+// Client-side on purpose, for the same reason the stale notice is: the SSR page
+// cache is keyed by asset version + country + timezone and carries no user-agent
+// component, so a server-side `detectPlayerFromRequest` would profile whichever
+// player happened to miss the cache and then attribute every subsequent hit to
+// it. The page has to report itself.
+
+import { isStalePlayer } from './stale-player.js'
+
+// GA4 has no null and no boolean in a param value — an absent param just makes
+// the dimension read "(not set)", which is indistinguishable from "we never
+// registered it". Send the profiler's nulls as an explicit value instead, so
+// "we looked and could not tell" is its own bucket in a report.
+export const UNKNOWN = 'unknown'
+
+// GA4 truncates a param value at 100 chars and drops the event if a param name
+// exceeds 40. Names here are well inside that; `model` is the only free-form
+// value (parsed straight out of a UA) so it is the only one worth clamping.
+const MAX_VALUE = 100
+
+const str = (value) => (value == null ? UNKNOWN : String(value).slice(0, MAX_VALUE))
+const bool = (value) => (value == null ? UNKNOWN : String(value))
+
+export const PLAYER_EVENT = 'player_detected'
+
+// Flatten a PlayerProfile into GA4 event params. Every field is prefixed
+// `player_` because these become custom dimensions in a property shared with the
+// other Screenly-Labs apps, where an unprefixed `vendor` or `model` would be
+// ambiguous.
+//
+// `sources` is deliberately not sent: in the browser only the user agent and
+// referrer are readable (the X-Requested-With header is not exposed to page JS),
+// so it is near-constant here and would spend a custom dimension on nothing.
+export const playerEventParams = (profile) => ({
+  player_vendor: str(profile.vendor),
+  player_platform: str(profile.platform),
+  player_model: str(profile.model),
+  player_category: str(profile.category),
+  // `engine` is always an object off detectPlayer (its fields are what go null),
+  // same assumption isStalePlayer makes about the very same profile.
+  player_engine: str(profile.engine.name),
+  // A number stays a number: this is the one field worth taking a median of, and
+  // GA4 will only do that for a numeric param.
+  player_engine_version: profile.engine.version ?? 0,
+  player_below_floor: bool(profile.belowFloor),
+  player_confidence: str(profile.confidence),
+  // Sent even though it is derivable from vendor + engine, because the
+  // definition of "stale" is a judgement call this app makes (see the note in
+  // stale-player.js) rather than something a report author should re-derive —
+  // and it is what makes notice impressions countable against upgrades.
+  player_stale: String(isStalePlayer(profile))
+})
+
+// Report the profile, once. `gtag` is absent whenever the env has no GA id (dev)
+// or the tag was blocked/failed to load, which is not an error worth surfacing on
+// an unattended screen — the clock is the product, telemetry is not. Returns
+// whether the event went out, so the caller and the tests can tell the no-op
+// case apart.
+export const trackPlayer = (profile, win = typeof window !== 'undefined' ? window : undefined) => {
+  if (typeof win?.gtag !== 'function') return false
+  win.gtag('event', PLAYER_EVENT, playerEventParams(profile))
+  return true
+}

--- a/assets/static/js/main.js
+++ b/assets/static/js/main.js
@@ -3,6 +3,7 @@
 import '@screenly-labs/signage-kit/polyfills'
 import { removeScreenlyBranding } from '@screenly-labs/signage-kit/branding'
 import { detectPlayer } from '@screenly-labs/signage-kit/profiler'
+import { trackPlayer } from './analytics.js'
 import { mountStaleNotice } from './stale-player.js'
 import {
   setLocale,
@@ -67,11 +68,18 @@ import {
     syncMinuteFill()
     renderClock()
     removeScreenlyBranding()
+    // Profile the player once and use it for both consumers below — the two
+    // questions ("should this screen be warned?" and "what is out there?") are
+    // the same detection, and one call keeps them from ever disagreeing.
+    const profile = detectPlayer()
     // Warn old-Anthias viewers that their player is out of date. Client-side on
     // purpose: the SSR page cache is keyed by asset version + country + timezone
     // and carries no user-agent component, so a server-rendered notice would be
     // cached and then served to every player regardless of what it is running.
-    mountStaleNotice(detectPlayer(), document, getAssetVersion())
+    mountStaleNotice(profile, document, getAssetVersion())
+    // Report the same profile to GA4, so the stale-player population we are
+    // warning is measurable rather than assumed.
+    trackPlayer(profile)
   }
 
   // Only auto-run in a real browser; under a test runner there is no document.

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'bun:test'
+import { detectPlayer } from '@screenly-labs/signage-kit/profiler'
+import {
+  playerEventParams,
+  trackPlayer,
+  PLAYER_EVENT,
+  UNKNOWN
+} from '../assets/static/js/analytics.js'
+
+// The same real UA strings the stale-notice suite pins, so both features are
+// asserted against one story about what each player actually sends.
+const UA = {
+  oldAnthias:
+    'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.15.2 Chrome/83.0.4103.122 Safari/537.36',
+  currentAnthias:
+    'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/6.8.2 Chrome/122.0.6261.171 Safari/537.36 Anthias/2026.7.1',
+  brightsign:
+    'BrightSign/UJE9C2001890/8.0.94 (XT1144)Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.11.2 Chrome/65.0.3325.230 Safari/537.36',
+  screenly:
+    'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.15.2 Chrome/83.0.4103.122 Safari/537.36 screenly-viewer/2.0',
+  bot: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+}
+
+const params = (ua) => playerEventParams(detectPlayer(ua, ''))
+
+// A window stub that records what gtag was called with.
+const fakeWindow = () => {
+  const calls = []
+  return { calls, gtag: (...args) => calls.push(args) }
+}
+
+describe('playerEventParams', () => {
+  it('reports a self-tagged player by vendor, engine and version', () => {
+    const p = params(UA.currentAnthias)
+    expect(p.player_vendor).toBe('anthias')
+    expect(p.player_category).toBe('signage')
+    expect(p.player_engine).toBe('qtwebengine')
+    expect(p.player_engine_version).toBe(122)
+    expect(p.player_below_floor).toBe('false')
+    expect(p.player_stale).toBe('false')
+  })
+
+  it('marks the untagged old-Anthias bucket as stale with no vendor', () => {
+    // The population the whole notice exists for has to be countable, and the
+    // profiler will not name a vendor for it — so `player_stale`, not
+    // `player_vendor`, is the dimension a report segments on.
+    const p = params(UA.oldAnthias)
+    expect(p.player_vendor).toBe(UNKNOWN)
+    expect(p.player_stale).toBe('true')
+    expect(p.player_below_floor).toBe('true')
+  })
+
+  it('carries the hardware model when the UA gives one', () => {
+    expect(params(UA.brightsign).player_model).toBe('XT1144')
+    expect(params(UA.brightsign).player_vendor).toBe('brightsign')
+  })
+
+  it('sends nulls as an explicit value, never as an absent param', () => {
+    // An omitted param is "(not set)" in GA4, which reads identically to a
+    // dimension nobody registered — so "we could not tell" must be its own value.
+    const p = params(UA.screenly)
+    expect(p.player_model).toBe(UNKNOWN)
+    for (const value of Object.values(p)) expect(value).toBeDefined()
+  })
+
+  it('keeps engine version numeric so GA4 can aggregate it', () => {
+    expect(typeof params(UA.screenly).player_engine_version).toBe('number')
+    // A bot has no engine at all; 0 stands in, since GA4 would coerce a string
+    // and lose every median across the property.
+    expect(params(UA.bot).player_engine_version).toBe(0)
+    expect(params(UA.bot).player_engine).toBe(UNKNOWN)
+    expect(params(UA.bot).player_category).toBe('bot')
+  })
+
+  it('sends an unreadable engine and floor verdict as unknown, not as a guess', () => {
+    // `belowFloor` is null when the engine version could not be read; reporting
+    // that as `false` would quietly count an unknown player as supported.
+    const p = playerEventParams({
+      vendor: null,
+      platform: null,
+      model: null,
+      category: 'browser',
+      engine: { name: null, version: null },
+      belowFloor: null,
+      confidence: 'low'
+    })
+    expect(p.player_engine).toBe(UNKNOWN)
+    expect(p.player_engine_version).toBe(0)
+    expect(p.player_below_floor).toBe(UNKNOWN)
+  })
+
+  it('clamps a value to GA4’s 100-char param limit', () => {
+    const p = playerEventParams({
+      vendor: null,
+      platform: null,
+      model: 'M'.repeat(500),
+      category: 'signage',
+      engine: { name: 'chromium', version: 90 },
+      belowFloor: false,
+      confidence: 'low'
+    })
+    expect(p.player_model.length).toBe(100)
+  })
+
+  it('names every param within GA4’s 40-char limit and stays under 25 params', () => {
+    const p = params(UA.currentAnthias)
+    expect(Object.keys(p).length).toBeLessThanOrEqual(25)
+    for (const name of Object.keys(p)) {
+      expect(name.length).toBeLessThanOrEqual(40)
+      expect(name).toMatch(/^[a-z][a-z0-9_]*$/)
+    }
+  })
+})
+
+describe('trackPlayer', () => {
+  it('sends one GA4 event carrying the params', () => {
+    const win = fakeWindow()
+    expect(trackPlayer(detectPlayer(UA.currentAnthias, ''), win)).toBe(true)
+    expect(win.calls.length).toBe(1)
+    const [command, name, sent] = win.calls[0]
+    expect(command).toBe('event')
+    expect(name).toBe(PLAYER_EVENT)
+    expect(sent.player_vendor).toBe('anthias')
+  })
+
+  it('is a silent no-op when gtag is absent', () => {
+    // No GA id in dev, and a blocked tag in the field — neither is worth throwing
+    // over on an unattended screen that should just keep showing the time.
+    expect(trackPlayer(detectPlayer(UA.screenly, ''), {})).toBe(false)
+    expect(trackPlayer(detectPlayer(UA.screenly, ''), { gtag: 'not-a-function' })).toBe(false)
+  })
+})


### PR DESCRIPTION
The stale-player notice already profiles every viewer to decide whether to warn it, but that judgement was made and thrown away on each load — so the population we're warning, and whether it ever shrinks, was unmeasurable.

This sends the same profile to GA4 as a `player_detected` event. One `detectPlayer()` call now feeds both consumers, so the notice and the telemetry can never disagree about what a screen is running.

Client-side for the same reason the notice is: the SSR page cache is keyed by asset version + country + timezone with no user-agent component, so a server-side profile would describe whichever player missed the cache and then be attributed to every hit behind it.

## The params

All prefixed `player_`, since the GA property is shared with the other Screenly-Labs apps:

| Param | Example |
|---|---|
| `player_vendor` | `anthias`, `brightsign`, `unknown` |
| `player_platform` | `linux` |
| `player_model` | `XT1144` |
| `player_category` | `signage`, `browser`, `bot` |
| `player_engine` | `qtwebengine` |
| `player_engine_version` | `83` (numeric) |
| `player_below_floor` | `true` |
| `player_confidence` | `high` |
| `player_stale` | `true` |

Three judgement calls worth review:

* **Nulls are sent as `"unknown"`, not omitted** — an absent param reads as "(not set)" in GA4, which is indistinguishable from a dimension nobody registered.
* **`engine_version` stays numeric** so GA4 will actually aggregate it.
* **`player_stale` is sent despite being derivable** from vendor + engine. "Stale" is a judgement this app makes (see the reasoning in `stale-player.js`) rather than something a report author should re-derive, and it's what makes notice impressions countable against upgrades.

`sources` is deliberately not sent: page JS can only read the UA and referrer (the `X-Requested-With` header isn't exposed), so it's near-constant here and would spend a custom dimension on nothing.

## Verification

Unit tests cover the param mapping against the same real player UA fixtures the stale-notice suite pins. Beyond that, I drove the **built bundle** in a browser across four spoofed player UAs — old Anthias, current Anthias, Screenly, BrightSign — with a stubbed `gtag` so nothing hit the live property:

* exactly one event per load, params correct per player
* `player_stale` agreed with whether the notice actually mounted
* no-`gtag` path (dev, or a blocked tag in the field) is a silent no-op with the clock still rendering

## Before this reports anything

The params stay invisible in reports until they're registered as custom definitions in the GA4 UI (Admin → Custom definitions) — `player_engine_version` as a metric, the rest as dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)